### PR TITLE
Added platform check when installing requirements

### DIFF
--- a/attack.py
+++ b/attack.py
@@ -55,10 +55,12 @@ logger.add(
 
 
 def check_req():
-    os.system("python3 -m pip install -r requirements.txt")
-    os.system("python -m pip install -r requirements.txt")
-    os.system("pip install -r requirements.txt")
-    os.system("pip3 install -r requirements.txt")
+    if platform.system() == "Windows":
+        os.system("python -m pip install -r requirements.txt")
+        os.system("pip install -r requirements.txt")
+    else:
+        os.system("python3 -m pip install -r requirements.txt")
+        os.system("pip3 install -r requirements.txt")
 
 
 def mainth(site: str):


### PR DESCRIPTION
If the platform is windows it uses python and pip. If it is not windows, it uses python3 and pip3.